### PR TITLE
test code on --release as well

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,8 @@ jobs:
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     displayName: 'Install rust'
   - script: rustc --version
-  - script: cargo test
-  - script: cargo test --release
+  - script: cargo test -- --nocapture
+  - script: cargo test --release -- --nocapture
 
 - job: macOS
   pool:
@@ -27,8 +27,8 @@ jobs:
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
     displayName: 'Install rust'
   - script: rustc --version
-  - script: cargo test
-  - script: cargo test --release
+  - script: cargo test -- --nocapture
+  - script: cargo test --release -- --nocapture
 
 - job: Windows
   pool:
@@ -40,5 +40,5 @@ jobs:
       echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
     displayName: 'Install rust'
   - script: rustc --version
-  - script: cargo test
-  - script: cargo test --release
+  - script: cargo test -- --nocapture
+  - script: cargo test --release -- --nocapture

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ jobs:
     displayName: 'Install rust'
   - script: rustc --version
   - script: cargo test
+  - script: cargo test --release
 
 - job: macOS
   pool:
@@ -27,6 +28,7 @@ jobs:
     displayName: 'Install rust'
   - script: rustc --version
   - script: cargo test
+  - script: cargo test --release
 
 - job: Windows
   pool:
@@ -39,3 +41,4 @@ jobs:
     displayName: 'Install rust'
   - script: rustc --version
   - script: cargo test
+  - script: cargo test --release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,8 @@ impl Vfs {
     }
 
     pub fn commit_changes(&mut self) -> Vec<VfsChange> {
+        // FIXME: ideally we should compact changes here, such that we send at
+        // most one event per VfsFile.
         mem::replace(&mut self.pending_changes, Vec::new())
     }
 
@@ -210,7 +212,9 @@ impl Vfs {
                         self.add_file_event(root, path, text, false);
                     }
                     (Some(file), Some(text)) => {
-                        self.change_file_event(file, text, false);
+                        if *self.file(file).text != text {
+                            self.change_file_event(file, text, false);
+                        }
                     }
                     (None, None) => (),
                 }


### PR DESCRIPTION
The code is timeout dependent, so additional --release testing should
be useful for making sure we don't actually depend on timings that
much.