### PR TITLE
 Implement Root based filtering for files and folders in Vfs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,15 +25,15 @@ use std::{
 };
 
 use crossbeam_channel::Receiver;
-use relative_path::{RelativePath, RelativePathBuf};
+pub use relative_path::{RelativePath, RelativePathBuf};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     io::{TaskResult, Worker},
-    roots::Roots,
+    roots::{Roots, FileType},
 };
 
-pub use crate::roots::VfsRoot;
+pub use crate::roots::{VfsRoot, RootEntry, Filter};
 
 /// Opaque wrapper around file-system event.
 ///
@@ -85,7 +85,7 @@ pub enum VfsChange {
 }
 
 impl Vfs {
-    pub fn new(roots: Vec<PathBuf>) -> (Vfs, Vec<VfsRoot>) {
+    pub fn new(roots: Vec<RootEntry>) -> (Vfs, Vec<VfsRoot>) {
         let roots = Arc::new(Roots::new(roots));
         let worker = io::start(Arc::clone(&roots));
         let mut root2files = FxHashMap::default();
@@ -281,7 +281,7 @@ impl Vfs {
     }
 
     fn find_root(&self, path: &Path) -> Option<(VfsRoot, RelativePathBuf, Option<VfsFile>)> {
-        let (root, path) = self.roots.find(&path)?;
+        let (root, path) = self.roots.find(&path, FileType::File)?;
         let file = self.find_file(root, &path);
         Some((root, path, file))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ use crate::{
     roots::{Roots, FileType},
 };
 
-pub use crate::roots::{VfsRoot};
+pub use crate::roots::VfsRoot;
 
 /// a `Filter` is used to determine whether a file or a folder
 /// under the specific root is included.

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -117,7 +117,7 @@ impl Roots {
 }
 
 impl RootData {
-    pub fn new(entry: RootEntry, excluded_dirs: Vec<RelativePathBuf>) -> Self {
+    fn new(entry: RootEntry, excluded_dirs: Vec<RelativePathBuf>) -> RootData {
         let mut canonical_path = entry.path.canonicalize().ok();
         if Some(&entry.path) == canonical_path.as_ref() {
             canonical_path = None;

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -3,72 +3,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use relative_path::{ RelativePath, RelativePathBuf};
+use relative_path::RelativePathBuf;
 
-/// a `Filter` is used to determine whether a file or a folder
-/// under the specific root is included.
-///
-/// *NOTE*: If the parent folder of a file is not included, then
-/// `include_file` will not be called.
-///
-/// # Example
-///
-/// Implementing `Filter` for rust files:
-///
-/// ```
-/// use ra_vfs::{Filter, RelativePath};
-///
-/// struct IncludeRustFiles;
-///
-/// impl Filter for IncludeRustFiles {
-///     fn include_dir(&self, dir_path: &RelativePath) -> bool {
-///         // These folders are ignored
-///         const IGNORED_FOLDERS: &[&str] = &["node_modules", "target", ".git"];
-///
-///         let is_ignored = dir_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
-///
-///         !is_ignored
-///     }
-///
-///     fn include_file(&self, file_path: &RelativePath) -> bool {
-///         // Only include rust files
-///         file_path.extension() == Some("rs")
-///     }
-/// }
-/// ```
-pub trait Filter: Send + Sync {
-    fn include_dir(&self, dir_path: &RelativePath) -> bool;
-    fn include_file(&self, file_path: &RelativePath) -> bool;
-}
-
-/// RootEntry identifies a root folder with a given filter
-/// used to determine whether to include or exclude files and folders under it.
-pub struct RootEntry {
-    path: PathBuf,
-    filter: Box<dyn Filter>,
-}
-
-impl std::fmt::Debug for RootEntry {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "RootEntry({})", self.path.display())
-    }
-}
-
-impl Eq for RootEntry {}
-impl PartialEq for RootEntry {
-    fn eq(&self, other: &Self) -> bool {
-        // Entries are equal based on their paths
-        self.path == other.path
-    }
-}
-
-impl RootEntry {
-    /// Create a new `RootEntry` with the given `filter` applied to
-    /// files and folder under it.
-    pub fn new(path: PathBuf, filter: Box<dyn Filter>) -> Self {
-        RootEntry { path, filter }
-    }
-}
+use super::{RootEntry, Filter};
 
 /// VfsRoot identifies a watched directory on the file system.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -21,11 +21,11 @@ use relative_path::{ RelativePath, RelativePathBuf};
 /// struct IncludeRustFiles;
 ///
 /// impl Filter for IncludeRustFiles {
-///     fn include_folder(&self, folder_path: &RelativePath) -> bool {
+///     fn include_dir(&self, dir_path: &RelativePath) -> bool {
 ///         // These folders are ignored
 ///         const IGNORED_FOLDERS: &[&str] = &["node_modules", "target", ".git"];
 ///
-///         let is_ignored = folder_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
+///         let is_ignored = dir_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
 ///
 ///         !is_ignored
 ///     }
@@ -37,7 +37,7 @@ use relative_path::{ RelativePath, RelativePathBuf};
 /// }
 /// ```
 pub trait Filter: Send + Sync {
-    fn include_folder(&self, folder_path: &RelativePath) -> bool;
+    fn include_dir(&self, dir_path: &RelativePath) -> bool;
     fn include_file(&self, file_path: &RelativePath) -> bool;
 }
 
@@ -198,7 +198,7 @@ impl RootData {
         }
 
         let parent_included =
-            rel_path.parent().map(|d| self.entry.filter.include_folder(&d)).unwrap_or(true);
+            rel_path.parent().map(|d| self.entry.filter.include_dir(&d)).unwrap_or(true);
 
         if !parent_included {
             return false;
@@ -206,7 +206,7 @@ impl RootData {
 
         match expected {
             FileType::File => self.entry.filter.include_file(&rel_path),
-            FileType::Dir => self.entry.filter.include_folder(&rel_path),
+            FileType::Dir => self.entry.filter.include_dir(&rel_path),
         }
     }
 }

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -7,6 +7,35 @@ use relative_path::{ RelativePath, RelativePathBuf};
 
 /// a `Filter` is used to determine whether a file or a folder
 /// under the specific root is included.
+///
+/// *NOTE*: If the parent folder of a file is not included, then
+/// `include_file` will not be called.
+///
+/// # Example
+///
+/// Implementing `Filter` for rust files:
+///
+/// ```
+/// use ra_vfs::{Filter, RelativePath};
+///
+/// struct IncludeRustFiles;
+///
+/// impl Filter for IncludeRustFiles {
+///     fn include_folder(&self, folder_path: &RelativePath) -> bool {
+///         // These folders are ignored
+///         const IGNORED_FOLDERS: &[&str] = &["node_modules", "target", ".git"];
+///
+///         let is_ignored = folder_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
+///
+///         !is_ignored
+///     }
+///
+///     fn include_file(&self, file_path: &RelativePath) -> bool {
+///         // Only include rust files
+///         file_path.extension() == Some("rs")
+///     }
+/// }
+/// ```
 pub trait Filter: Send + Sync {
     fn include_folder(&self, folder_path: &RelativePath) -> bool;
     fn include_file(&self, file_path: &RelativePath) -> bool;

--- a/tests/vfs.rs
+++ b/tests/vfs.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, fs, time::Duration};
 
 // use flexi_logger::Logger;
 use crossbeam_channel::RecvTimeoutError;
-use ra_vfs::{Vfs, VfsChange};
+use ra_vfs::{Vfs, VfsChange, RootEntry, Filter, RelativePath};
 use tempfile::tempdir;
 
 /// Processes exactly `num_tasks` events waiting in the `vfs` message queue.
@@ -40,6 +40,112 @@ macro_rules! assert_match {
     };
 }
 
+struct IncludeRustFiles;
+
+impl IncludeRustFiles {
+    fn boxed() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl Filter for IncludeRustFiles {
+    fn include_folder(&self, folder_path: &RelativePath) -> bool {
+        const IGNORED_FOLDERS: &[&str] = &["node_modules", "target", ".git"];
+
+        let is_ignored = folder_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
+
+        let hidden = folder_path.file_stem().map(|s| s.starts_with(".")).unwrap_or(false);
+
+        !is_ignored && !hidden
+    }
+
+    fn include_file(&self, file_path: &RelativePath) -> bool {
+        file_path.extension() == Some("rs")
+    }
+}
+
+#[test]
+fn test_vfs_ignore() -> std::io::Result<()> {
+    // flexi_logger::Logger::with_str("vfs=debug,ra_vfs=debug").start().unwrap();
+
+    let files = [
+        ("ignore_a/foo.rs", "hello"),
+        ("ignore_a/bar.rs", "world"),
+        ("ignore_a/b/baz.rs", "nested hello"),
+        ("ignore_a/LICENSE", "extensionless file"),
+        ("ignore_a/b/AUTHOR", "extensionless file"),
+        ("ignore_a/.hidden.txt", "hidden file"),
+        ("ignore_a/.hidden_folder/file.rs", "hidden folder containing rust file"),
+        (
+            "ignore_a/.hidden_folder/nested/foo.rs",
+            "file inside nested folder inside a hidden folder",
+        ),
+        ("ignore_a/node_modules/module.js", "hidden file js"),
+        ("ignore_a/node_modules/module2.rs", "node rust"),
+        ("ignore_a/node_modules/nested/foo.bar", "hidden file bar"),
+    ];
+
+    let dir = tempdir().unwrap();
+    for (path, text) in files.iter() {
+        let file_path = dir.path().join(path);
+        fs::create_dir_all(file_path.parent().unwrap()).unwrap();
+        fs::write(file_path, text)?
+    }
+
+    let a_root = dir.path().join("ignore_a");
+    let b_root = dir.path().join("ignore_a/b");
+
+    let (mut vfs, _) = Vfs::new(vec![
+        RootEntry::new(a_root, IncludeRustFiles::boxed()),
+        RootEntry::new(b_root, IncludeRustFiles::boxed()),
+    ]);
+    process_tasks(&mut vfs, 2);
+    {
+        let files = vfs
+            .commit_changes()
+            .into_iter()
+            .flat_map(|change| {
+                let files = match change {
+                    VfsChange::AddRoot { files, .. } => files,
+                    _ => panic!("unexpected change"),
+                };
+                files.into_iter().map(|(_id, path, text)| {
+                    let text: String = (&*text).clone();
+                    (format!("{}", path.display()), text)
+                })
+            })
+            .collect::<HashSet<_>>();
+
+        let expected_files = [("foo.rs", "hello"), ("bar.rs", "world"), ("baz.rs", "nested hello")]
+            .iter()
+            .map(|(path, text)| (path.to_string(), text.to_string()))
+            .collect::<HashSet<_>>();
+
+        assert_eq!(files, expected_files);
+    }
+
+    // rust-analyzer#734: fsevents has a bunch of events still sitting around.
+    process_tasks_in_range(&mut vfs, 0, if cfg!(target_os = "macos") { 7 } else { 0 });
+    assert!(vfs.commit_changes().is_empty());
+
+    // These will get filtered out
+    vfs.add_file_overlay(&dir.path().join("ignore_a/node_modules/spam.rs"), "spam".to_string());
+    vfs.add_file_overlay(&dir.path().join("ignore_a/node_modules/spam2.rs"), "spam".to_string());
+    vfs.add_file_overlay(&dir.path().join("ignore_a/node_modules/spam3.rs"), "spam".to_string());
+    vfs.add_file_overlay(&dir.path().join("ignore_a/LICENSE2"), "text".to_string());
+    assert_match!(vfs.commit_changes().as_slice(), []);
+
+    fs::create_dir_all(dir.path().join("ignore_a/node_modules/sub1")).unwrap();
+    fs::write(dir.path().join("ignore_a/node_modules/sub1/new.rs"), "new hello").unwrap();
+
+    assert_match!(
+        vfs.task_receiver().recv_timeout(Duration::from_millis(300)), // slightly more than watcher debounce delay
+        Err(RecvTimeoutError::Timeout)
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_vfs_works() -> std::io::Result<()> {
     // Logger::with_str("vfs=debug,ra_vfs=debug").start().unwrap();
@@ -63,7 +169,10 @@ fn test_vfs_works() -> std::io::Result<()> {
     let a_root = dir.path().join("a");
     let b_root = dir.path().join("a/b");
 
-    let (mut vfs, _) = Vfs::new(vec![a_root, b_root]);
+    let (mut vfs, _) = Vfs::new(vec![
+        RootEntry::new(a_root, IncludeRustFiles::boxed()),
+        RootEntry::new(b_root, IncludeRustFiles::boxed()),
+    ]);
     process_tasks(&mut vfs, 2);
     {
         let files = vfs

--- a/tests/vfs.rs
+++ b/tests/vfs.rs
@@ -49,12 +49,12 @@ impl IncludeRustFiles {
 }
 
 impl Filter for IncludeRustFiles {
-    fn include_folder(&self, folder_path: &RelativePath) -> bool {
+    fn include_dir(&self, dir_path: &RelativePath) -> bool {
         const IGNORED_FOLDERS: &[&str] = &["node_modules", "target", ".git"];
 
-        let is_ignored = folder_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
+        let is_ignored = dir_path.components().any(|c| IGNORED_FOLDERS.contains(&c.as_str()));
 
-        let hidden = folder_path.file_stem().map(|s| s.starts_with(".")).unwrap_or(false);
+        let hidden = dir_path.file_stem().map(|s| s.starts_with(".")).unwrap_or(false);
 
         !is_ignored && !hidden
     }


### PR DESCRIPTION
The filtering is done through implementing the trait `Filter` which is then applied to folders and files under the given `RootEntry`.

This relates to discussion in https://github.com/rust-analyzer/rust-analyzer/issues/869 and in [zulip](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Fwg-rls-2.2E0/topic/ignoring.20in.20VFS) . This allows users to provide filtering for each root. Enabling to have crate specific filtering applied, so for example for external crates you may exclude `test|bench|example` folders.
