### PR TITLE
Fixes deduplication of Vfs roots

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,3 +362,29 @@ impl Vfs {
         &mut self.files[file.0 as usize]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct NoopFilter;
+
+    impl Filter for NoopFilter {
+        fn include_dir(&self, _: &RelativePath) -> bool {
+            true
+        }
+        fn include_file(&self, _: &RelativePath) -> bool {
+            true
+        }
+    }
+
+    fn entry(s: &str) -> RootEntry {
+        RootEntry::new(s.into(), Box::new(NoopFilter))
+    }
+
+    #[test]
+    fn vfs_deduplicates() {
+        let entries = vec!["/foo", "/bar", "/foo"].into_iter().map(entry).collect();
+        let (_, roots) = Vfs::new(entries);
+        assert_eq!(roots.len(), 2);
+    }
+}

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -52,9 +52,11 @@ pub(crate) struct Roots {
 
 impl Roots {
     pub(crate) fn new(mut paths: Vec<RootEntry>) -> Roots {
+        paths.sort_by(|a, b| a.path.cmp(&b.path));
+        paths.dedup();
+
         // A hack to make nesting work.
         paths.sort_by_key(|it| std::cmp::Reverse(it.path.as_os_str().len()));
-        paths.dedup();
 
         // First gather all the nested roots for each path
         let nested_roots = paths


### PR DESCRIPTION
If two roots happen to have the same length and one of them is repeated, deduplicating by path length might not work. I've experienced this while debugging `ra_lsp_server`.

Noob disclaimer: I'm not sure if deduplication _should_ be guaranteed, if that unit test is something you want, if sorting twice is overkill, etc.