### PR TITLE
Fixed panic when working with non-utf8 paths

### DIFF
--- a/src/roots.rs
+++ b/src/roots.rs
@@ -154,8 +154,7 @@ impl RootData {
 /// Returns the path relative to `base`
 fn rel_path(base: &Path, path: &Path) -> Option<RelativePathBuf> {
     let path = path.strip_prefix(base).ok()?;
-    let path = RelativePathBuf::from_path(path).unwrap();
-    Some(path)
+    RelativePathBuf::from_path(path).ok()
 }
 
 /// Returns the path relative to `base` with filtering applied based on `data`


### PR DESCRIPTION
This fixes a panic I got when I had some non-utf8 files in my working directory for testing purposes. You can create such a file with:

    $ touch 'Hello'$'\303''(World.txt'