### PR TITLE
Add path2root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,11 @@ impl Vfs {
         self.roots.path(root).to_path_buf()
     }
 
+    pub fn path2root(&self, path: &Path) -> Option<VfsRoot> {
+        let (root, _path) = self.roots.find(path, FileType::Dir)?;
+        Some(root)
+    }
+
     pub fn path2file(&self, path: &Path) -> Option<VfsFile> {
         if let Some((_root, _path, Some(file))) = self.find_root(path) {
             return Some(file);


### PR DESCRIPTION
Adds a function to get the `VfsRoot` for a given path (if any). Needed for my OUT_DIR work over in the main rust-analyzer repo